### PR TITLE
feat: google calendar apiを使って予定を取得できるようにした

### DIFF
--- a/mypage/calendar/.gitignore
+++ b/mypage/calendar/.gitignore
@@ -2,3 +2,4 @@ vendor/
 key/
 .env
 ../calendar-2-main/
+common.php

--- a/mypage/calendar/GetSchedule.php
+++ b/mypage/calendar/GetSchedule.php
@@ -1,18 +1,42 @@
 <?php
-include 'common.php';
+// require_once __DIR__ . '/common.php';
 // 予定の取得
+require __DIR__ . '/vendor/autoload.php';
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+$dotenv->load();
 
-// カレンダーID (晒すのは怖いからenvファイルに書いておく)
+// envファイルで隠しとく
 $calendarId = $_ENV['CALENDAR_ID'];
+$api_key = $_ENV['API_KEY'];
 
 // 取得時の詳細設定
 $optParams = array(
     'maxResults' => 10,
     'orderBy' => 'startTime',
     'singleEvents' => true,
-    'timeMin' => date('c', strtotime('2024-01-01')),
+    'timeMin' => date('c', strtotime('2024-01-01'))
 );
 
-$results = $service->events->listEvents($calendarId, $optParams);
-$events = $results->getItems();
+$API_URL = 'https://www.googleapis.com/calendar/v3/calendars/'.$calendarId.'/events?key='.$api_key.'&singleEvents=true';
+
+// 予定の取得クエリを合体
+$url = $API_URL.'&'.implode('&', $optParams);
+
+// urlからjsonを取得
+$results = file_get_contents($url);
+$json = json_decode($results, true);
+ 
+foreach ($json['items'] as $item) {
+    /*
+    * 基本的なキーワード
+    * created : 作成日
+    * summary : イベント名
+    * start : 開始日時
+    * end : 終了日時
+    * description : 詳細
+    */
+    // こんな感じで予定の種痘が出来る
+    // 後日DBに挿入するコーディングをする
+    echo '開催日:'.$item['created'].'| イベント名:'.$item['summary'].'<br>';
+}
 ?>

--- a/mypage/calendar/calendar.php
+++ b/mypage/calendar/calendar.php
@@ -1,5 +1,3 @@
-<?php include 'GetSchedule.php'; ?>
-
 <!DOCTYPE html>
 <html lang="ja">
 
@@ -10,12 +8,6 @@
 <body>
     <h1>イベントカレンダー</h1>
     <?php echo "<iframe src=\"{$_ENV['CALENDAR_URL']}\" style='border: 0;' height=800 width=800 frameborder='0' scrolling='no'></iframe>"; ?>
-    <?php foreach ($events as $event) : ?>
-        <h2><?php echo $event->getSummary(); ?></h2>
-        <p><?php echo $event->getDescription(); ?></p>
-        <p><?php echo $event->getStart()->dateTime; ?></p>
-        <p><?php echo $event->getEnd()->dateTime; ?></p>
-    <?php endforeach; ?>
 </body>
 
 </html>


### PR DESCRIPTION
## 課題

- 個々のカレンダーではなく共有としている(後々変える)
- DBへどういう形式で送るかは思案中
- apiがdevToolsのネットワークタブから見れば丸見え(不正なリクエストが出来てしまう)
- カレンダーに直接書き込めない(google calendarのアプリから予定を入力する必要がある)

## 解決策

- カレンダーに直接書き込めないのは、apiから書き込むことが出来るので問題ない(少し不便)
- 個々のカレンダーではなく、ラベルで分ければフィルタリングがしやすい(adminの場合は管理がしやすい)