### PR TITLE
feat(share-btn): ブログにシェアボタンを追加

### DIFF
--- a/blog-post.html
+++ b/blog-post.html
@@ -51,6 +51,16 @@
             </div>
         </div>
 
+        <!-- シェアボタン -->
+        <div class="share-buttons">
+            <button class="share-btn share-x" type="button" aria-label="Xで共有">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
+            </button>
+            <button class="share-btn share-copy" type="button" aria-label="リンクをコピー">
+                <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24"><path d="M13.723 18.654l-3.61 3.609c-2.316 2.315-6.063 2.315-8.378 0-1.12-1.118-1.735-2.606-1.735-4.188 0-1.582.615-3.07 1.734-4.189l4.866-4.865c2.355-2.355 6.114-2.262 8.377 0 .453.453.81.973 1.089 1.527l-1.593 1.592c-.18-.613-.5-1.189-.964-1.652-1.448-1.448-3.93-1.51-5.439-.001l-.001.002-4.867 4.865c-1.5 1.499-1.5 3.941 0 5.44 1.517 1.517 3.958 1.488 5.442 0l2.425-2.424c.993.284 1.791.335 2.654.284zm.161-16.918l-3.574 3.576c.847-.05 1.655 0 2.653.283l2.393-2.389c1.498-1.502 3.94-1.5 5.44-.001 1.517 1.518 1.486 3.959 0 5.442l-4.831 4.831-.003.002c-1.438 1.437-3.886 1.552-5.439-.002-.473-.474-.785-1.042-.956-1.643l-.084.068-1.517 1.515c.28.556.635 1.075 1.088 1.528 2.245 2.245 6.004 2.374 8.378 0l4.832-4.831c2.314-2.316 2.316-6.062-.001-8.377-2.317-2.321-6.067-2.313-8.379-.002z"/></svg>
+            </button>
+        </div>
+
         <div id="prev"><a href="./blog.html">← ブログトップへ戻る</a></div>
     </main>
 
@@ -59,6 +69,7 @@
 
     <script type="module" src="./script/loadCommon.js"></script>
     <script type="module" src="./script/blog/blogPostRenderer.js"></script>
+    <script type="module" src="./script/blog/shareButtons.js"></script>
     <script type="module">
         if (window.matchMedia("(min-width: 820px)").matches) {
             import("./script/blog/archiveListRenderer.js");

--- a/css/blog-temp.css
+++ b/css/blog-temp.css
@@ -214,7 +214,47 @@ main .pc-only {
     left: -5px;
 }
 
+/* ===== シェアボタン（仮スタイル） ===== */
+.share-buttons {
+    position: fixed;
+    left: 16px;
+    top: 50%;
+    transform: translateY(-50%);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    z-index: 100;
+}
+.share-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    border: none;
+    border-radius: 50%;
+    background-color: #fff;
+    color: #333;
+    box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.12), 0 2px 6px rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+    transition: background-color 0.2s, color 0.2s;
+}
+.share-btn:hover {
+    background-color: var(--main-color);
+    color: #fff;
+}
+.share-btn svg {
+    pointer-events: none;
+}
+
 @media (max-width: 819px) {
+    .share-buttons {
+        position: static;
+        transform: none;
+        flex-direction: row;
+        justify-content: center;
+        margin: 16px auto;
+    }
     .breadcrumbs {
         font-size: 0.9em;
     }

--- a/script/blog/shareButtons.js
+++ b/script/blog/shareButtons.js
@@ -1,0 +1,36 @@
+/**
+ * シェアボタンの共有ロジック
+ */
+
+function getShareData() {
+    const url = location.href;
+    const titleEl = document.getElementById('blog-title');
+    const title = titleEl ? titleEl.textContent.trim() : document.title;
+    return { url, title };
+}
+
+function showCheckmark(btn) {
+    const originalHTML = btn.innerHTML;
+    btn.innerHTML = '<svg width="24" height="24" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd"><path d="M24 4.685l-16.327 17.315-7.673-9.054.761-.648 6.95 8.203 15.561-16.501.728.685z"/></svg>';
+    setTimeout(() => { btn.innerHTML = originalHTML; }, 1500);
+}
+
+function handleShareX() {
+    const { url, title } = getShareData();
+    const intentUrl = `https://x.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}`;
+    window.open(intentUrl, '_blank', 'noopener,noreferrer,width=550,height=420');
+}
+
+async function handleCopyLink(e) {
+    const btn = e.currentTarget;
+    const { url } = getShareData();
+    try {
+        await navigator.clipboard.writeText(url);
+        showCheckmark(btn);
+    } catch {
+        // fallback: do nothing
+    }
+}
+
+document.querySelectorAll('.share-x').forEach(btn => btn.addEventListener('click', handleShareX));
+document.querySelectorAll('.share-copy').forEach(btn => btn.addEventListener('click', handleCopyLink));


### PR DESCRIPTION
## why

ブログを多くの人に見てもらうための工夫として必要だと感じた。
広報部がより簡単に共有できると感じた。

## 見てほしいこと

- [x] mainでかなりリファクタをしたので既存のcssやhtmlファイルで矛盾が起きていないか
- [x] デザイン崩れがないか
- 共有ボタン
  - [x] PCでは左側で縦にフローティング表示されているか
  - [x] SPではページ下部に横並びで表示されているか
  - [x] リンクコピーボタンでコピーされるか
- X共有ボタン
  - [x] PCで別ウィンドウで共有画面が開くか
  - [x] SPでXのアプリに飛ばされ、共有画面が開くか

## やったこと

ブログ詳細ページに共有ボタンを配置した。
PCでは左側にフローティング表示する
SPでは記事下部にボタンを配置する

## 懸念

配置・デザインに関しては暫定