### PR TITLE
fix(calendar): イベント詳細を見やすく

### DIFF
--- a/mypage-kamagi/pages/mypage/auth.js
+++ b/mypage-kamagi/pages/mypage/auth.js
@@ -13,7 +13,55 @@ document.addEventListener('DOMContentLoaded', async () => {
     document.getElementById('user-name').textContent = user.name;
 
     const events = await fetchEvents(user.id);
-    diplayEvents(events);
+    displayEvents(events);
 });
 
 
+/**
+ * APIからユーザーに紐づくイベント一覧を取得して表示する
+ * 
+ * @param {string} userId 
+ */
+async function fetchEvents(userId) {
+    try {
+        const response = await eventService.getEvents({ userId: userId });
+        if (!response.events) return null;
+        return response.events;
+    } catch (error) {
+        console.error('Error fetching events:', error);
+        return null;
+    }
+}
+
+/**
+ * イベントデータを受け取り、イベントカードを生成して表示する
+ * 
+ * @param {Object[]} events イベントデータの配列
+ * @param {string} events[].id イベントID
+ * @param {string} events[].title イベントタイトル
+ * @param {string} events[].start イベント開始日時
+ * @param {string} events[].end イベント終了日時
+ * @param {string} events[].description イベント説明（任意）
+ * @param {string} events[].visibility イベントの公開範囲（"public", "private"）
+ * @param {Object[]} events[].participants 参加者情報の配列
+ * @param {string} events[].participants[].id 参加者ID
+ * @param {string} events[].participants[].name 参加者名
+ */
+function displayEvents(events) {
+    const eventList = document.getElementById('event-list');
+    const noEvents = document.getElementById('no-events');
+
+    if (!events || events.length === 0) {
+        noEvents.style.display = 'block';
+        eventList.style.display = 'none';
+        return;
+    }
+    
+    noEvents.style.display = 'none';
+    eventList.style.display = 'grid';
+    const fragment = document.createDocumentFragment();
+    events.forEach(event => {
+        fragment.appendChild(createEventCard(event));
+    });
+    eventList.replaceChildren(fragment);
+}

--- a/mypage-kamagi/pages/mypage/fetch-event.js
+++ b/mypage-kamagi/pages/mypage/fetch-event.js
@@ -24,7 +24,7 @@ function diplayEvents(events) {
         row.innerHTML = `
             <td>${event.title}</td>
             <td>${formatedDate}</td>
-            <td>${event.description}</td>
+            <td>${formatDescription(event.description)}</td>
             <td>${composeParticipants(event.participants)}</td>
         `;
         eventList.appendChild(row);
@@ -50,6 +50,13 @@ async function fetchEvents(userId) {
 function composeParticipants(participants) {
     if (!participants || participants.length === 0) return '全員';
     return participants.map(participant => participant.name).join(', ');
+}
+
+function formatDescription(description) {
+    if (!description) return '';
+    description = description.replace(/\n/g, '<br>');
+    const container = "<details><summary>イベント詳細を確認する</summary>" + description + "</details>";
+    return container;
 }
 
 /**

--- a/mypage-kamagi/pages/mypage/fetch-event.js
+++ b/mypage-kamagi/pages/mypage/fetch-event.js
@@ -1,68 +1,91 @@
 /**
- * マイページにイベント一覧を表示する
- * auth.jsの読み込み後に呼び出される
+ * イベント表示に関するユーティリティ関数
  */
 
-function diplayEvents(events) {
-    const eventList = document.getElementById('event-list');
-    const noEvents = document.getElementById('no-events');
+/** イベントカードを作成する */
+function createEventCard(event) {
+    const card = document.createElement('div');
+    card.className = 'event-card';
 
-    if (!events || events.length === 0) {
-        noEvents.style.display = 'block';
-        eventList.style.display = 'none';
-        return;
+    const cardHeader = document.createElement('div');
+    cardHeader.className = 'event-card-header';
+
+    const title = document.createElement('span');
+    title.className = 'event-title';
+    title.textContent = event.title || '';
+    cardHeader.appendChild(title);
+
+    const cardBody = document.createElement('div');
+    cardBody.className = 'event-card-body';
+
+    const formattedDate = formatEventDate(event.start, event.end);
+    const participants = composeParticipants(event.participants);
+    cardBody.appendChild(createEventMeta(formattedDate, participants));
+
+    if (event.description) {
+        cardBody.appendChild(createDescriptionElement(event.description));
     }
-    
-    noEvents.style.display = 'none';
-    eventList.style.display = 'grid';
-    eventList.innerHTML = '';
-    events.forEach(event => {
-        const card = document.createElement('div');
-        card.className = 'event-card';
-        const formatedDate = formatEventDate(event.start, event.end);
-        const participants = composeParticipants(event.participants);
-        card.innerHTML = `
-            <div class="event-card-header">
-                <span class="event-title">${event.title}</span>
-            </div>
-            <div class="event-card-body">
-                <div class="event-meta">
-                    <span class="event-date"><i class="fa fa-calendar"></i> ${formatedDate}</span>
-                    <span class="event-participants"><i class="fa fa-users"></i> ${participants}</span>
-                </div>
-                ${event.description ? formatDescription(event.description) : ''}
-            </div>
-        `;
-        eventList.appendChild(card);
-    });
+
+    card.append(cardHeader, cardBody);
+    return card;
 }
+
+/** イベントのメタ情報（日時と参加者）を作成する */
+function createEventMeta(formattedDate, participants) {
+    const meta = document.createElement('div');
+    meta.className = 'event-meta';
+
+    const dateLabel = createIconText('event-date', 'fa fa-calendar', formattedDate);
+    const participantsLabel = createIconText('event-participants', 'fa fa-users', participants);
+
+    meta.append(dateLabel, participantsLabel);
+    return meta;
+}
+
+/** イベントの日時と参加者情報をアイコン付きで表示する要素を作成する */
+function createIconText(labelClassName, iconClassName, text) {
+    const label = document.createElement('span');
+    label.className = labelClassName;
+
+    const icon = document.createElement('i');
+    icon.className = iconClassName;
+
+    label.append(icon, document.createTextNode(` ${text || ''}`));
+    return label;
+}
+
 
 /**
- * APIからユーザーに紐づくイベント一覧を取得して表示する
+ * 参加者情報の配列を受け取り、参加者名をカンマ区切りで連結した文字列を返す
  * 
- * @param {string} userId 
+ * @param {Object[]} participants 
+ * @param {string} participants[].id 参加者ID
+ * @param {string} participants[].name 参加者名
+ * @returns {string} 参加者名の文字列
  */
-async function fetchEvents(userId) {
-    try {
-        const response = await eventService.getEvents({ userId: userId });
-        if (!response.events) return null;
-        return response.events;
-    } catch (error) {
-        console.error('Error fetching events:', error);
-        return null;
-    }
-}
-
 function composeParticipants(participants) {
+    // participants:[]のときは全員とする
     if (!participants || participants.length === 0) return '全員';
-    return participants.map(participant => participant.name).join(', ');
+    const names = participants
+        .map(participant => (participant && participant.name ? String(participant.name) : ''))
+        .filter(name => name.length > 0);
+    // participants:[{id: '11111111, name: ''}]みたいなときは不正
+    return names.length > 0 ? names.join(', ') : '正しく参加者情報が取得できませんでした';
 }
 
-function formatDescription(description) {
-    if (!description) return '';
-    description = description.replace(/\n/g, '<br>');
-    const container = "<details><summary>イベント詳細を確認する</summary>" + description + "</details>";
-    return container;
+function createDescriptionElement(description) {
+    const details = document.createElement('details');
+    const summary = document.createElement('summary');
+    summary.textContent = 'イベント詳細を確認する';
+    details.appendChild(summary);
+
+    const lines = String(description).split(/\r?\n/);
+    lines.forEach((line, index) => {
+        if (index > 0) details.appendChild(document.createElement('br'));
+        details.appendChild(document.createTextNode(line));
+    });
+
+    return details;
 }
 
 /**
@@ -75,7 +98,7 @@ function formatDescription(description) {
 function formatEventDate(start, end) {
     const startDate = new Date(start);
     const endDate = new Date(end);
-    if (!startDate || !endDate) return '';
+    if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) return '';
     const diffDays = (endDate - startDate) / (1000 * 60 * 60 * 24);
     if (diffDays >= 1) {
         return `${formatDate(startDate)} 〜 ${formatDate(endDate)}`;

--- a/mypage-kamagi/pages/mypage/fetch-event.js
+++ b/mypage-kamagi/pages/mypage/fetch-event.js
@@ -69,21 +69,28 @@ function composeParticipants(participants) {
     const names = participants
         .map(participant => (participant && participant.name ? String(participant.name) : ''))
         .filter(name => name.length > 0);
-    // participants:[{id: '11111111, name: ''}]みたいなときは不正
+    // participants:[{id: '11111111', name: ''}]みたいなときは不正
     return names.length > 0 ? names.join(', ') : '正しく参加者情報が取得できませんでした';
 }
 
 function createDescriptionElement(description) {
     const details = document.createElement('details');
+    details.className = 'event-description';
+
     const summary = document.createElement('summary');
+    summary.className = 'event-description-summary';
     summary.textContent = 'イベント詳細を確認する';
-    details.appendChild(summary);
+
+    const content = document.createElement('div');
+    content.className = 'event-description-content';
 
     const lines = String(description).split(/\r?\n/);
     lines.forEach((line, index) => {
-        if (index > 0) details.appendChild(document.createElement('br'));
-        details.appendChild(document.createTextNode(line));
+        if (index > 0) content.appendChild(document.createElement('br'));
+        content.appendChild(document.createTextNode(line));
     });
+
+    details.append(summary, content);
 
     return details;
 }

--- a/mypage-kamagi/pages/mypage/fetch-event.js
+++ b/mypage-kamagi/pages/mypage/fetch-event.js
@@ -4,30 +4,36 @@
  */
 
 function diplayEvents(events) {
-    const eventListTable = document.getElementById('event-list-table');
     const eventList = document.getElementById('event-list');
     const noEvents = document.getElementById('no-events');
 
     if (!events || events.length === 0) {
-        // イベントデータが存在しないことを伝える。
         noEvents.style.display = 'block';
-        eventListTable.style.display = 'none';
+        eventList.style.display = 'none';
         return;
     }
     
     noEvents.style.display = 'none';
-    eventListTable.style.display = 'block';
+    eventList.style.display = 'grid';
     eventList.innerHTML = '';
     events.forEach(event => {
-        const row = document.createElement('tr');
+        const card = document.createElement('div');
+        card.className = 'event-card';
         const formatedDate = formatEventDate(event.start, event.end);
-        row.innerHTML = `
-            <td>${event.title}</td>
-            <td>${formatedDate}</td>
-            <td>${formatDescription(event.description)}</td>
-            <td>${composeParticipants(event.participants)}</td>
+        const participants = composeParticipants(event.participants);
+        card.innerHTML = `
+            <div class="event-card-header">
+                <span class="event-title">${event.title}</span>
+            </div>
+            <div class="event-card-body">
+                <div class="event-meta">
+                    <span class="event-date"><i class="fa fa-calendar"></i> ${formatedDate}</span>
+                    <span class="event-participants"><i class="fa fa-users"></i> ${participants}</span>
+                </div>
+                ${event.description ? formatDescription(event.description) : ''}
+            </div>
         `;
-        eventList.appendChild(row);
+        eventList.appendChild(card);
     });
 }
 

--- a/mypage-kamagi/pages/mypage/index.html
+++ b/mypage-kamagi/pages/mypage/index.html
@@ -29,7 +29,7 @@
     </div>
 
     <div id="calender">
-        <h2> カレンダー</h2>
+        <h2>カレンダー</h2>
         <span style="font-weight: bold;">スマホでは「スケジュール」表示にすると見やすいです。</span>
         <iframe 
             src="https://calendar.google.com/calendar/embed?src=a23bec7bb1a50a07c46df692888fee89c66547fedf575d44f1a333f8804848c1%40group.calendar.google.com&ctz=Asia%2FTokyo" 

--- a/mypage-kamagi/pages/mypage/index.html
+++ b/mypage-kamagi/pages/mypage/index.html
@@ -23,25 +23,16 @@
     <div id="event-list-container">
         <h2>イベント一覧</h2>
         <p id="no-events">表示できるイベントがありません。</p>
-        <table id="event-list-table">
-            <thead>
-                <tr>
-                    <th>イベント名</th>
-                    <th>日時</th>
-                    <th>詳細</th>
-                    <th>参加者</th>
-                </tr>
-            </thead>
-            <tbody id="event-list">
-                <!-- イベントデータが表示されます -->
-            </tbody>
-        </table>
+        <div id="event-list">
+            <!-- イベントカードが表示されます -->
+        </div>
     </div>
 
     <div id="calender">
-        <h2>カレンダー</h2>
+        <h2> カレンダー</h2>
+        <span style="font-weight: bold;">スマホでは「スケジュール」表示にすると見やすいです。</span>
         <iframe 
-            src="https://calendar.google.com/calendar/embed?src=a23bec7bb1a50a07c46df692888fee89c66547fedf575d44f1a333f8804848c1%40group.calendar.google.com&ctz=Asia%2FTokyo" 
+            src="https://calendar.google.com/calendar/embed?src=6bc8d4c70139097818ef94f5abc1439ec71bb2f72ba59e062cb5f452ebc32ece%40group.calendar.google.com&ctz=Asia%2FTokyo" 
             style="border-width: 0" 
             width="100%" 
             height="600" 

--- a/mypage-kamagi/pages/mypage/index.html
+++ b/mypage-kamagi/pages/mypage/index.html
@@ -32,7 +32,7 @@
         <h2> カレンダー</h2>
         <span style="font-weight: bold;">スマホでは「スケジュール」表示にすると見やすいです。</span>
         <iframe 
-            src="https://calendar.google.com/calendar/embed?src=6bc8d4c70139097818ef94f5abc1439ec71bb2f72ba59e062cb5f452ebc32ece%40group.calendar.google.com&ctz=Asia%2FTokyo" 
+            src="https://calendar.google.com/calendar/embed?src=a23bec7bb1a50a07c46df692888fee89c66547fedf575d44f1a333f8804848c1%40group.calendar.google.com&ctz=Asia%2FTokyo" 
             style="border-width: 0" 
             width="100%" 
             height="600" 

--- a/mypage-kamagi/pages/mypage/mypage.css
+++ b/mypage-kamagi/pages/mypage/mypage.css
@@ -73,44 +73,109 @@ body {
     padding: 20px;
 }
 
-/* テーブル */
-table {
-    width: auto;
-    margin-left: auto;
-    margin-right: auto;
-    border-collapse: collapse;
-    text-align: center;
-    font-size: 0.95em;
+/* イベントカード一覧 */
+#event-list {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 12px;
+    width: 100%;
 }
 
-th {
+.event-card {
+    border: 1px solid #e8e8e8;
+    border-radius: 8px;
+    overflow: hidden;
+    transition: box-shadow 0.2s, transform 0.15s;
+}
+
+.event-card:hover {
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    transform: translateY(-2px);
+}
+
+.event-card-header {
     background-color: var(--main-color);
-    color: white;
-    padding: 12px 10px;
+    padding: 12px 16px;
+}
+
+.event-title {
+    color: #fff;
     font-weight: 600;
+    font-size: 1em;
 }
 
-th:first-child {
-    border-radius: 6px 0 0 0;
+.event-card-body {
+    padding: 14px 16px;
 }
 
-th:last-child {
-    border-radius: 0 6px 0 0;
+.event-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 8px;
+    font-size: 0.9em;
+    color: #555;
 }
 
-td {
+.event-meta i {
+    color: var(--main-color);
+    margin-right: 4px;
+}
+
+.event-date,
+.event-participants {
+    display: flex;
+    align-items: center;
+}
+
+/* イベント詳細 details */
+.event-card details {
+    cursor: pointer;
+    border-radius: 6px;
+    padding: 6px 10px;
+    margin-top: 6px;
+    transition: background-color 0.2s, box-shadow 0.2s;
+}
+
+.event-card details summary {
+    font-size: 0.9em;
+    color: var(--main-color);
+    font-weight: 500;
+    list-style: none;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+.event-card details summary::before {
+    content: '▶';
+    font-size: 0.7em;
+    transition: transform 0.2s;
+}
+
+.event-card details[open] summary::before {
+    transform: rotate(90deg);
+}
+
+.event-card details summary::-webkit-details-marker {
+    display: none;
+}
+
+.event-card details:hover {
+    background-color: #f0f7ff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+}
+
+.event-card details[open] {
+    background-color: #f9f9f9;
     border: 1px solid #e0e0e0;
-    padding: 12px 10px;
-    color: #444;
 }
 
-tr:nth-child(even) {
-    background-color: #fafafa;
-}
-
-tr:hover {
-    background-color: #f5f5f5;
-    transition: background-color 0.2s;
+.event-card details[open] > *:not(summary) {
+    margin-top: 8px;
+    font-size: 0.88em;
+    color: #555;
+    line-height: 1.6;
 }
 
 /* カレンダーセクション */
@@ -175,11 +240,16 @@ tr:hover {
         padding: 15px;
     }
 
-    table {
-        font-size: 0.85em;
+    .event-card-header {
+        padding: 10px 12px;
     }
 
-    th, td {
-        padding: 8px 5px;
+    .event-card-body {
+        padding: 10px 12px;
+    }
+
+    .event-meta {
+        flex-direction: column;
+        gap: 6px;
     }
 }

--- a/mypage-kamagi/pages/mypage/mypage.css
+++ b/mypage-kamagi/pages/mypage/mypage.css
@@ -129,15 +129,15 @@ body {
 }
 
 /* イベント詳細 details */
-.event-card details {
-    cursor: pointer;
+.event-description {
     border-radius: 6px;
     padding: 6px 10px;
     margin-top: 6px;
     transition: background-color 0.2s, box-shadow 0.2s;
 }
 
-.event-card details summary {
+.event-description-summary {
+    cursor: pointer;
     font-size: 0.9em;
     color: var(--main-color);
     font-weight: 500;
@@ -147,31 +147,31 @@ body {
     gap: 6px;
 }
 
-.event-card details summary::before {
+.event-description-summary::before {
     content: '▶';
     font-size: 0.7em;
     transition: transform 0.2s;
 }
 
-.event-card details[open] summary::before {
+.event-description[open] .event-description-summary::before {
     transform: rotate(90deg);
 }
 
-.event-card details summary::-webkit-details-marker {
+.event-description-summary::-webkit-details-marker {
     display: none;
 }
 
-.event-card details:hover {
+.event-description:hover {
     background-color: #f0f7ff;
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
 }
 
-.event-card details[open] {
+.event-description[open] {
     background-color: #f9f9f9;
     border: 1px solid #e0e0e0;
 }
 
-.event-card details[open] > *:not(summary) {
+.event-description-content {
     margin-top: 8px;
     font-size: 0.88em;
     color: #555;


### PR DESCRIPTION
## 変更
- `details`タグで詳細を開閉できるように
- 改行を適応できるように。

キャプチャ
| 開閉前 | 開閉後|
| - | - |
| <img width="604" height="158" alt="image" src="https://github.com/user-attachments/assets/808550b3-fed1-4b12-a630-e1a0525ff7a5" /> | <img width="600" height="556" alt="image" src="https://github.com/user-attachments/assets/486c5012-42ed-4185-b941-8ecdf9e42ced" /> |

## 見てほしいこと

- [x] デザイン崩れがないか(PC,SP)
- [x] 改行が反映されるか
- [x] 開閉のUI/UXはどうか