### PR TITLE
fix(design): イベント管理ページを見やすく

### DIFF
--- a/mypage-kamagi/pages/event/event-delete.js
+++ b/mypage-kamagi/pages/event/event-delete.js
@@ -8,7 +8,29 @@
  */
 function toggleDeleteWarning(show) {
     const deleteWarning = document.getElementById('delete-warning');
-    deleteWarning.style.display = show ? 'block' : 'none';
+    deleteWarning.style.display = show ? 'flex' : 'none';
+}
+
+/**
+ * 削除プレビューの表示
+ * @param {string} eventId イベントID
+ */
+function showDeletePreview(eventId) {
+    const preview = document.getElementById('delete-preview');
+    const previewTitle = document.getElementById('delete-preview-title');
+    const previewDate = document.getElementById('delete-preview-date');
+
+    if (!eventId) {
+        preview.style.display = 'none';
+        return;
+    }
+
+    const event = eventsCache.find(e => e.id === eventId);
+    if (event) {
+        previewTitle.textContent = event.title;
+        previewDate.textContent = formatDateTime(event.start) + ' 〜 ' + formatDateTime(event.end);
+        preview.style.display = 'block';
+    }
 }
 
 /**
@@ -46,9 +68,10 @@ function setupDeleteForm() {
         return;
     }
     
-    // イベント選択時に警告を表示
+    // イベント選択時に警告とプレビューを表示
     deleteSelect.addEventListener('change', () => {
         toggleDeleteWarning(!!deleteSelect.value);
+        showDeletePreview(deleteSelect.value);
     });
     
     // 削除フォーム送信

--- a/mypage-kamagi/pages/event/event-update.js
+++ b/mypage-kamagi/pages/event/event-update.js
@@ -81,17 +81,20 @@ async function updateEvent(formValues) {
  */
 function handleUpdateEventSelect() {
     const updateSelect = document.getElementById('update-event-select');
+    const updateForm = document.getElementById('update-event-form');
     const selectedId = updateSelect.value;
     
-    // 何も選択していない場合はクリア
+    // 何も選択していない場合はクリア＆非表示
     if (!selectedId) {
         clearUpdateForm();
+        updateForm.classList.remove('visible');
         return;
     }
     
     const event = eventsCache.find(e => e.id === selectedId);
     if (event) {
         populateUpdateForm(event);
+        updateForm.classList.add('visible');
     }
 }
 
@@ -138,6 +141,7 @@ function setupUpdateForm() {
             // セレクトをリセット
             updateSelect.value = '';
             clearUpdateForm();
+            updateForm.classList.remove('visible');
             
         } catch (error) {
             showToast(error.message, 'error');

--- a/mypage-kamagi/pages/event/event.js
+++ b/mypage-kamagi/pages/event/event.js
@@ -11,6 +11,9 @@ let eventsCache = [];
 let membersCache = [];
 
 document.addEventListener('DOMContentLoaded', async () => {
+    // タブ切り替えのセットアップ
+    setupTabs();
+
     // 初期化: メンバー一覧とイベント一覧を取得
     await Promise.all([
         loadMembers(),
@@ -22,6 +25,32 @@ document.addEventListener('DOMContentLoaded', async () => {
     setupUpdateForm();
     setupDeleteForm();
 });
+
+/**
+ * タブ切り替え機能のセットアップ
+ */
+function setupTabs() {
+    const tabBtns = document.querySelectorAll('.tab-btn');
+    const tabPanels = document.querySelectorAll('.tab-panel');
+
+    tabBtns.forEach(btn => {
+        btn.addEventListener('click', () => {
+            const targetTab = btn.dataset.tab;
+
+            // ボタンのアクティブ状態を切り替え
+            tabBtns.forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+
+            // パネルの表示を切り替え
+            tabPanels.forEach(panel => {
+                panel.classList.remove('active');
+                if (panel.id === `${targetTab}-section`) {
+                    panel.classList.add('active');
+                }
+            });
+        });
+    });
+}
 
 /**
  * メンバー一覧を取得して参加者セレクトボックスに表示

--- a/mypage-kamagi/pages/event/index.html
+++ b/mypage-kamagi/pages/event/index.html
@@ -12,42 +12,60 @@
 <body class="anim-fadein" style="display:none;">
     <main>
         <header>
-            <h1>イベント管理</h1>
+            <h1><i class="fa fa-calendar"></i> イベント管理</h1>
             <a href="../mypage/index.html" class="back-link">
-                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                    <path d="M19 12H5M12 19l-7-7 7-7"/>
-                </svg>
+                <i class="fa fa-arrow-left"></i>
                 マイページに戻る
             </a>
         </header>
 
-        <div class="event-forms-container">
-            <!-- Create Event Section -->
-            <section class="card" id="create-section">
-                <h2>新規イベント作成</h2>
+        <!-- タブナビゲーション -->
+        <nav class="tab-nav">
+            <button class="tab-btn active" data-tab="create">
+                <i class="fa fa-plus-circle"></i>
+                <span>作成</span>
+            </button>
+            <button class="tab-btn" data-tab="update">
+                <i class="fa fa-pencil"></i>
+                <span>編集</span>
+            </button>
+            <button class="tab-btn" data-tab="delete">
+                <i class="fa fa-trash"></i>
+                <span>削除</span>
+            </button>
+        </nav>
+
+        <!-- Create Event Section -->
+        <section class="tab-panel active" id="create-section">
+            <div class="card">
+                <div class="card-header">
+                    <h2><i class="fa fa-plus-circle"></i> 新規イベント作成</h2>
+                    <p class="card-desc">新しいイベントを作成してカレンダーに追加します。</p>
+                </div>
                 <form id="create-event-form">
                     <div class="form-group">
-                        <label for="create-title">イベント名</label>
+                        <label for="create-title"><i class="fa fa-tag"></i> イベント名</label>
                         <input type="text" id="create-title" name="title" required placeholder="例：新入生歓迎会">
                     </div>
                     
                     <div class="form-group">
-                        <label for="create-description">詳細・説明</label>
+                        <label for="create-description"><i class="fa fa-align-left"></i> 詳細・説明</label>
                         <textarea id="create-description" name="description" rows="4" placeholder="イベントの詳細を入力してください"></textarea>
                     </div>
 
-                    <div class="form-group">
-                        <label for="create-start-time">開始日時</label>
-                        <input type="datetime-local" id="create-start-time" name="start_time" required>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="create-start-time"><i class="fa fa-clock-o"></i> 開始日時</label>
+                            <input type="datetime-local" id="create-start-time" name="start_time" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="create-end-time"><i class="fa fa-clock-o"></i> 終了日時</label>
+                            <input type="datetime-local" id="create-end-time" name="end_time" required>
+                        </div>
                     </div>
 
                     <div class="form-group">
-                        <label for="create-end-time">終了日時</label>
-                        <input type="datetime-local" id="create-end-time" name="end_time" required>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="create-visibility">公開設定</label>
+                        <label for="create-visibility"><i class="fa fa-eye"></i> 公開設定</label>
                         <select id="create-visibility" name="visibility">
                             <option value="public">公開（全員参加可能）</option>
                             <option value="private">非公開（招待のみ）</option>
@@ -55,56 +73,62 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="create-participants">参加者（Ctrl/Cmdキーで複数選択）</label>
+                        <label for="create-participants"><i class="fa fa-users"></i> 参加者</label>
                         <select id="create-participants" name="participant_ids" multiple size="5">
                             <!-- JSで動的に追加 -->
                         </select>
-                        <small class="form-hint">任意：参加者を選択するとカレンダーにも表示されます</small>
+                        <small class="form-hint">Ctrl/Cmdキーで複数選択可。選択するとカレンダーにも表示されます。</small>
                     </div>
 
-                    <button type="submit" class="btn btn-primary">イベントを作成</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-check"></i> イベントを作成
+                    </button>
                 </form>
-            </section>
+            </div>
+        </section>
 
-            <!-- Update Event Section -->
-            <section class="card" id="update-section">
-                <h2>イベント更新</h2>
-                
-                <div class="selection-area">
-                    <div class="form-group">
-                        <label for="update-event-select">編集するイベントを選択</label>
-                        <select id="update-event-select">
-                            <option value="">イベントを選択してください</option>
-                            <!-- JSで動的に追加 -->
-                        </select>
-                    </div>
+        <!-- Update Event Section -->
+        <section class="tab-panel" id="update-section">
+            <div class="card">
+                <div class="card-header">
+                    <h2><i class="fa fa-pencil"></i> イベント編集</h2>
+                    <p class="card-desc">既存のイベントの内容を変更します。</p>
                 </div>
 
-                <form id="update-event-form">
+                <div class="selection-area">
+                    <label for="update-event-select"><i class="fa fa-search"></i> 編集するイベント</label>
+                    <select id="update-event-select">
+                        <option value="">イベントを選択してください</option>
+                        <!-- JSで動的に追加 -->
+                    </select>
+                </div>
+
+                <form id="update-event-form" class="hidden-form">
                     <input type="hidden" id="update-event-id" name="event_id">
                     
                     <div class="form-group">
-                        <label for="update-title">イベント名</label>
+                        <label for="update-title"><i class="fa fa-tag"></i> イベント名</label>
                         <input type="text" id="update-title" name="title" required>
                     </div>
                     
                     <div class="form-group">
-                        <label for="update-description">詳細・説明</label>
+                        <label for="update-description"><i class="fa fa-align-left"></i> 詳細・説明</label>
                         <textarea id="update-description" name="description" rows="4"></textarea>
                     </div>
 
-                    <div class="form-group">
-                        <label for="update-start-time">開始日時</label>
-                        <input type="datetime-local" id="update-start-time" name="start_time" required>
+                    <div class="form-row">
+                        <div class="form-group">
+                            <label for="update-start-time"><i class="fa fa-clock-o"></i> 開始日時</label>
+                            <input type="datetime-local" id="update-start-time" name="start_time" required>
+                        </div>
+                        <div class="form-group">
+                            <label for="update-end-time"><i class="fa fa-clock-o"></i> 終了日時</label>
+                            <input type="datetime-local" id="update-end-time" name="end_time" required>
+                        </div>
                     </div>
 
                     <div class="form-group">
-                        <label for="update-end-time">終了日時</label>
-                        <input type="datetime-local" id="update-end-time" name="end_time" required>
-                    </div>
-
-                    <div class="form-group">
-                        <label for="update-visibility">公開設定</label>
+                        <label for="update-visibility"><i class="fa fa-eye"></i> 公開設定</label>
                         <select id="update-visibility" name="visibility">
                             <option value="public">公開</option>
                             <option value="private">非公開</option>
@@ -112,37 +136,57 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="update-participants">参加者（Ctrl/Cmdキーで複数選択）</label>
+                        <label for="update-participants"><i class="fa fa-users"></i> 参加者</label>
                         <select id="update-participants" name="participant_ids" multiple size="5">
                             <!-- JSで動的に追加 -->
                         </select>
-                        <small class="form-hint">任意：参加者を選択するとカレンダーにも表示されます</small>
+                        <small class="form-hint">Ctrl/Cmdキーで複数選択可。選択するとカレンダーにも表示されます。</small>
                     </div>
 
-                    <button type="submit" class="btn btn-primary">変更を保存</button>
+                    <button type="submit" class="btn btn-primary">
+                        <i class="fa fa-save"></i> 変更を保存
+                    </button>
                 </form>
-            </section>
+            </div>
+        </section>
 
-            <!-- Delete Event Section -->
-            <section class="card" id="delete-section">
-                <h2>イベント削除</h2>
+        <!-- Delete Event Section -->
+        <section class="tab-panel" id="delete-section">
+            <div class="card">
+                <div class="card-header">
+                    <h2><i class="fa fa-trash"></i> イベント削除</h2>
+                    <p class="card-desc">不要なイベントを削除します。</p>
+                </div>
+
                 <form id="delete-event-form">
                     <div class="form-group">
-                        <label for="delete-event-select">削除するイベントを選択</label>
+                        <label for="delete-event-select"><i class="fa fa-search"></i> 削除するイベント</label>
                         <select id="delete-event-select">
                             <option value="">イベントを選択してください</option>
                             <!-- JSで動的に追加 -->
                         </select>
                     </div>
+
+                    <!-- 選択されたイベントのプレビュー -->
+                    <div id="delete-preview" class="delete-preview" style="display: none;">
+                        <h3>削除対象のイベント</h3>
+                        <div class="preview-content">
+                            <p><strong>イベント名:</strong> <span id="delete-preview-title"></span></p>
+                            <p><strong>日時:</strong> <span id="delete-preview-date"></span></p>
+                        </div>
+                    </div>
                     
-                    <div id="delete-warning" style="color: #ef4444; margin-bottom: 15px; font-size: 0.9rem; display: none;">
-                        ※この操作は取り消せません。
+                    <div id="delete-warning" class="delete-warning" style="display: none;">
+                        <i class="fa fa-exclamation-triangle"></i>
+                        この操作は取り消せません。削除されたイベントは復元できません。
                     </div>
 
-                    <button type="submit" class="btn btn-danger">イベントを削除</button>
+                    <button type="submit" class="btn btn-danger">
+                        <i class="fa fa-trash"></i> イベントを削除
+                    </button>
                 </form>
-            </section>
-        </div>
+            </div>
+        </section>
     </main>
 
     <!-- Libs -->

--- a/mypage-kamagi/pages/event/style.css
+++ b/mypage-kamagi/pages/event/style.css
@@ -1,27 +1,38 @@
 body {
-    background-color: var(--bg-color);
+    background-color: #f0f0f0;
     margin: 0;
     padding: 20px;
     color: #333;
 }
 
 main {
-    max-width: 1200px;
+    max-width: 700px;
     margin: 0 auto;
-    padding: 20px;
+    padding: 0;
 }
 
 header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 30px;
+    margin-bottom: 24px;
+    background: #fff;
+    padding: 20px 24px;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
 h1 {
     color: var(--main-color);
     margin: 0;
-    font-size: 2rem;
+    font-size: 1.5rem;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+h1 i {
+    font-size: 1.2em;
 }
 
 .back-link {
@@ -29,42 +40,106 @@ h1 {
     color: #666;
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    transition: color 0.3s;
+    gap: 6px;
+    font-size: 0.9rem;
+    padding: 8px 14px;
+    border-radius: 6px;
+    transition: all 0.2s;
 }
 
 .back-link:hover {
     color: var(--main-color);
+    background-color: #f0f7ff;
 }
 
-.event-forms-container {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
-    gap: 30px;
-}
-
-.card {
-    background-color: var(--bg-color-2);
-    padding: 30px;
-    border-radius: 12px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-}
-
-.card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 8px 15px rgba(0, 0, 0, 0.1);
-}
-
-.card h2 {
-    color: var(--main-color);
-    margin-top: 0;
+/* タブナビゲーション */
+.tab-nav {
+    display: flex;
+    gap: 4px;
     margin-bottom: 20px;
-    border-bottom: 2px solid #ddd;
-    padding-bottom: 10px;
-    font-size: 1.5rem;
+    background: #fff;
+    padding: 6px;
+    border-radius: 12px;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
 
+.tab-btn {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 12px 16px;
+    border: none;
+    background: transparent;
+    border-radius: 8px;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: #666;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.tab-btn:hover {
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+.tab-btn.active {
+    background-color: var(--main-color);
+    color: #fff;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.tab-btn i {
+    font-size: 1.1em;
+}
+
+/* タブパネル */
+.tab-panel {
+    display: none;
+}
+
+.tab-panel.active {
+    display: block;
+    animation: fadeIn 0.3s ease;
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(8px); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+/* カード */
+.card {
+    background-color: #fff;
+    padding: 28px;
+    border-radius: 12px;
+    box-shadow: 0 2px 12px rgba(0, 0, 0, 0.06);
+}
+
+.card-header {
+    margin-bottom: 24px;
+    padding-bottom: 16px;
+    border-bottom: 2px solid #f0f0f0;
+}
+
+.card-header h2 {
+    color: var(--main-color);
+    margin: 0 0 6px 0;
+    font-size: 1.3rem;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.card-desc {
+    color: #888;
+    margin: 0;
+    font-size: 0.9rem;
+}
+
+/* フォーム */
 .form-group {
     margin-bottom: 20px;
 }
@@ -72,21 +147,45 @@ h1 {
 .form-group label {
     display: block;
     margin-bottom: 8px;
-    font-weight: bold;
-    color: #555;
+    font-weight: 600;
+    color: #444;
+    font-size: 0.9rem;
+}
+
+.form-group label i {
+    color: var(--main-color);
+    margin-right: 4px;
+    width: 16px;
+    text-align: center;
 }
 
 .form-group input,
 .form-group select,
 .form-group textarea {
     width: 100%;
-    padding: 10px;
-    border: 1px solid #ddd;
-    border-radius: 6px;
+    padding: 12px 14px;
+    border: 2px solid #e8e8e8;
+    border-radius: 8px;
     font-size: 1rem;
-    background-color: #fff;
+    background-color: #fafafa;
     box-sizing: border-box;
-    transition: border-color 0.3s;
+    transition: border-color 0.2s, background-color 0.2s, box-shadow 0.2s;
+}
+
+.form-group input:hover,
+.form-group select:hover,
+.form-group textarea:hover {
+    border-color: #ccc;
+    background-color: #fff;
+}
+
+.form-group input:focus,
+.form-group select:focus,
+.form-group textarea:focus {
+    border-color: var(--main-color);
+    background-color: #fff;
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(10, 140, 216, 0.1);
 }
 
 .form-group textarea {
@@ -94,23 +193,29 @@ h1 {
     min-height: 100px;
 }
 
-.form-group input:focus,
-.form-group select:focus,
-.form-group textarea:focus {
-    border-color: var(--main-color);
-    outline: none;
+/* 横並びフォーム行 */
+.form-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
 }
 
+/* ボタン */
 .btn {
     width: 100%;
-    padding: 12px;
+    padding: 14px;
     border: none;
-    border-radius: 6px;
+    border-radius: 8px;
     font-size: 1rem;
-    font-weight: bold;
+    font-weight: 600;
     cursor: pointer;
-    transition: all 0.3s ease;
+    transition: all 0.2s;
     color: #fff;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    margin-top: 8px;
 }
 
 .btn-primary {
@@ -119,43 +224,95 @@ h1 {
 
 .btn-primary:hover {
     opacity: 0.9;
-    box-shadow: 0 4px 10px rgba(10, 140, 216, 0.3);
+    box-shadow: 0 4px 12px rgba(10, 140, 216, 0.3);
+    transform: translateY(-1px);
 }
 
 .btn-danger {
-    background-color: #ef4444; /* Red for delete/danger */
+    background-color: #ef4444;
 }
 
 .btn-danger:hover {
     background-color: #dc2626;
-    box-shadow: 0 4px 10px rgba(239, 68, 68, 0.3);
+    box-shadow: 0 4px 12px rgba(239, 68, 68, 0.3);
+    transform: translateY(-1px);
 }
 
-/* Specific styling for the update section to separate selection from form */
+.btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    transform: none;
+    box-shadow: none;
+}
+
+/* イベント選択エリア */
 .selection-area {
-    background-color: #f0f4f8;
-    padding: 15px;
-    border-radius: 8px;
+    background-color: #f8fafc;
+    padding: 18px;
+    border-radius: 10px;
     margin-bottom: 20px;
-    border-left: 4px solid var(--main-color);
+    border: 2px solid #e8f0fe;
 }
 
-/* Form hint text */
+.selection-area label {
+    display: block;
+    margin-bottom: 8px;
+    font-weight: 600;
+    color: #444;
+    font-size: 0.9rem;
+}
+
+.selection-area label i {
+    color: var(--main-color);
+    margin-right: 4px;
+}
+
+.selection-area select {
+    width: 100%;
+    padding: 12px 14px;
+    border: 2px solid #e8e8e8;
+    border-radius: 8px;
+    font-size: 1rem;
+    background-color: #fff;
+    box-sizing: border-box;
+    transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.selection-area select:focus {
+    border-color: var(--main-color);
+    outline: none;
+    box-shadow: 0 0 0 3px rgba(10, 140, 216, 0.1);
+}
+
+/* 更新フォーム非表示状態 */
+.hidden-form {
+    display: none;
+    animation: fadeIn 0.3s ease;
+}
+
+.hidden-form.visible {
+    display: block;
+}
+
+/* フォームヒント */
 .form-hint {
     display: block;
-    margin-top: 5px;
-    font-size: 0.85rem;
-    color: #666;
+    margin-top: 6px;
+    font-size: 0.82rem;
+    color: #888;
 }
 
-/* Multiple select styling */
+/* 複数選択 */
 .form-group select[multiple] {
     height: auto;
-    min-height: 120px;
+    min-height: 130px;
+    padding: 6px;
 }
 
 .form-group select[multiple] option {
-    padding: 8px 10px;
+    padding: 10px 12px;
+    border-radius: 4px;
+    margin-bottom: 2px;
 }
 
 .form-group select[multiple] option:checked {
@@ -163,8 +320,80 @@ h1 {
     color: white;
 }
 
-/* Loading state */
-.btn:disabled {
-    opacity: 0.7;
-    cursor: not-allowed;
+/* 削除プレビュー */
+.delete-preview {
+    background: #fff8f8;
+    border: 2px solid #fecaca;
+    border-radius: 10px;
+    padding: 16px;
+    margin-bottom: 16px;
+}
+
+.delete-preview h3 {
+    margin: 0 0 10px 0;
+    font-size: 0.9rem;
+    color: #b91c1c;
+}
+
+.preview-content p {
+    margin: 4px 0;
+    font-size: 0.9rem;
+    color: #555;
+}
+
+/* 削除警告 */
+.delete-warning {
+    background: #fef2f2;
+    border: 1px solid #fecaca;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin-bottom: 16px;
+    font-size: 0.88rem;
+    color: #b91c1c;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.delete-warning i {
+    font-size: 1.1em;
+}
+
+/* レスポンシブ */
+@media (max-width: 600px) {
+    body {
+        padding: 10px;
+    }
+
+    header {
+        flex-direction: column;
+        gap: 12px;
+        text-align: center;
+        padding: 16px;
+    }
+
+    h1 {
+        font-size: 1.3rem;
+    }
+
+    .tab-btn span {
+        display: none;
+    }
+
+    .tab-btn {
+        padding: 12px;
+    }
+
+    .tab-btn i {
+        font-size: 1.3em;
+    }
+
+    .card {
+        padding: 20px;
+    }
+
+    .form-row {
+        grid-template-columns: 1fr;
+        gap: 0;
+    }
 }


### PR DESCRIPTION
## 変更
- イベントの作成・更新・削除をタブで遷移する

キャプチャ
| 作成タブ | 更新タブ | 削除タブ |
| - | - | - |
| <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/a405f547-ac45-4d92-a473-a12d27201602" /> | <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/879e9999-1bf9-495d-94ed-baf3ac623e9f" /> | <img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/afe34fd5-3ce7-49f1-b692-05e870255e7a" /> |

## 見てほしいこと

必須
- [x] デザイン崩れがないか(PC,SP)
- [x] タブの遷移が行えるか
- [x] それぞれのタブで機能漏れがないか

任意
- UI/UXの改善余地など
