### PR TITLE
ブログメーカー: id を `yy-mm-dd-event` で自動生成し、画像命名を連番化 (#157)

### DIFF
--- a/mypage-kamagi/pages/app/blog-maker/index.html
+++ b/mypage-kamagi/pages/app/blog-maker/index.html
@@ -64,7 +64,7 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label for="article-id">id（イベント名）</label>
-                                <input id="article-id" name="id" type="text" placeholder="yugyou06" data-field="id" pattern="[A-Za-z0-9_]+" title="半角英数字と_のみ入力できます" required>
+                                <input id="article-id" name="id" type="text" placeholder="例) yugyou06" data-field="id" pattern="[A-Za-z0-9_]+" title="半角英数字と_のみ入力できます" required>
                             </div>
 
                             <div class="form-group">

--- a/mypage-kamagi/pages/app/blog-maker/index.html
+++ b/mypage-kamagi/pages/app/blog-maker/index.html
@@ -64,7 +64,7 @@
                         <div class="form-grid">
                             <div class="form-group">
                                 <label for="article-id">id（イベント名）</label>
-                                <input id="article-id" name="id" type="text" placeholder="yugyou06" data-field="id" required>
+                                <input id="article-id" name="id" type="text" placeholder="yugyou06" data-field="id" pattern="[A-Za-z0-9_]+" title="半角英数字と_のみ入力できます" required>
                             </div>
 
                             <div class="form-group">

--- a/mypage-kamagi/pages/app/blog-maker/index.html
+++ b/mypage-kamagi/pages/app/blog-maker/index.html
@@ -63,8 +63,8 @@
                         <h3>基本情報</h3>
                         <div class="form-grid">
                             <div class="form-group">
-                                <label for="article-id">id</label>
-                                <input id="article-id" name="id" type="text" placeholder="25-08-08-sciencesummer" data-field="id" required>
+                                <label for="article-id">id（イベント名）</label>
+                                <input id="article-id" name="id" type="text" placeholder="yugyou06" data-field="id" required>
                             </div>
 
                             <div class="form-group">

--- a/mypage-kamagi/pages/app/blog-maker/modules/image-processor.js
+++ b/mypage-kamagi/pages/app/blog-maker/modules/image-processor.js
@@ -48,35 +48,15 @@ function convertToWebp(file) {
 }
 
 /**
- * ランダムな英数字文字列を生成する
- * @param {number} length - 文字列の長さ（デフォルト5）
- * @returns {string} 英数字のランダム文字列
- */
-function generateRandomId(length = 5) {
-    const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
-    let result = "";
-    for (let i = 0; i < length; i++) {
-        result += chars.charAt(Math.floor(Math.random() * chars.length));
-    }
-    return result;
-}
-
-/**
  * 命名規則に従った画像ファイル名を生成する
- * @param {string} dateStr - "YYYY-MM-DD" 形式の日付
- * @param {string} randomTag - 1エクスポート内で共有するランダム文字列
+ * @param {string} articleId - 記事ID（yy-mm-dd-event 形式）
  * @param {number} index - 画像番号（1始まり、2桁ゼロ埋め）
- * @returns {string} "yy-mm-dd-randomTag-nn.webp"
+ * @returns {string} "yy-mm-dd-event-nn.webp"
  */
-function generateImageFilename(dateStr, randomTag, index) {
-    const parts = dateStr.split("-");
-    const yy = parts[0] ? parts[0].slice(-2) : "00";
-    const mm = parts[1] || "01";
-    const dd = parts[2] || "01";
-
+function generateImageFilename(articleId, index) {
+    const safeArticleId = String(articleId || "").trim() || DEFAULT_ARTICLE_BASE_NAME;
     const nn = String(index).padStart(2, "0");
-
-    return `${yy}-${mm}-${dd}-${randomTag}-${nn}.webp`;
+    return `${safeArticleId}-${nn}.webp`;
 }
 
 /**

--- a/mypage-kamagi/pages/app/blog-maker/modules/import.js
+++ b/mypage-kamagi/pages/app/blog-maker/modules/import.js
@@ -69,7 +69,7 @@ async function importFromZip(file) {
 function restoreStateFromJson(json, imageBlobs) {
     cleanupPreviousState();
 
-    state.id = json.id || "";
+    state.id = extractEventId(json.id, json.date);
     state.date = json.date || "";
     state.title = json.title || "";
     state.caption = json.caption || "";

--- a/mypage-kamagi/pages/app/blog-maker/modules/utils.js
+++ b/mypage-kamagi/pages/app/blog-maker/modules/utils.js
@@ -4,6 +4,71 @@
  */
 
 const ALLOWED_LAYOUTS = new Set(["horizontal", "vertical"]);
+const ARTICLE_ID_PATTERN = /^(\d{2}-\d{2}-\d{2})-(.+)$/;
+const DEFAULT_ARTICLE_BASE_NAME = "article";
+
+function buildDatePrefix(dateStr) {
+    const matched = String(dateStr || "").trim().match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+    if (!matched) {
+        return "";
+    }
+
+    const year = matched[1];
+    const month = matched[2];
+    const day = matched[3];
+
+    const monthNumber = Number(month);
+    const dayNumber = Number(day);
+    if (monthNumber < 1 || monthNumber > 12 || dayNumber < 1 || dayNumber > 31) {
+        return "";
+    }
+
+    const parsedDate = new Date(Number(year), monthNumber - 1, dayNumber);
+    if (
+        parsedDate.getFullYear() !== Number(year) ||
+        parsedDate.getMonth() !== monthNumber - 1 ||
+        parsedDate.getDate() !== dayNumber
+    ) {
+        return "";
+    }
+
+    const yy = year.slice(-2);
+    const mm = month.padStart(2, "0");
+    const dd = day.padStart(2, "0");
+
+    return `${yy}-${mm}-${dd}`;
+}
+
+function buildArticleId(dateStr, eventId) {
+    const prefix = buildDatePrefix(dateStr);
+    const safeEventId = String(eventId || "").trim();
+    if (!prefix) {
+        return safeEventId;
+    }
+    if (!safeEventId) {
+        return prefix;
+    }
+    return `${prefix}-${safeEventId}`;
+}
+
+function extractEventId(articleId, dateStr) {
+    const rawId = String(articleId || "").trim();
+    if (!rawId) {
+        return "";
+    }
+
+    const prefix = buildDatePrefix(dateStr);
+    if (prefix && rawId.startsWith(`${prefix}-`)) {
+        return rawId.slice(prefix.length + 1);
+    }
+
+    const matched = rawId.match(ARTICLE_ID_PATTERN);
+    if (matched) {
+        return matched[2];
+    }
+
+    return rawId;
+}
 
 function escapeHtml(value) {
     const map = {

--- a/mypage-kamagi/pages/app/blog-maker/modules/utils.js
+++ b/mypage-kamagi/pages/app/blog-maker/modules/utils.js
@@ -6,6 +6,20 @@
 const ALLOWED_LAYOUTS = new Set(["horizontal", "vertical"]);
 const ARTICLE_ID_PATTERN = /^(\d{2}-\d{2}-\d{2})-(.+)$/;
 const DEFAULT_ARTICLE_BASE_NAME = "article";
+const EVENT_ID_ALLOWED_PATTERN = /^[A-Za-z0-9_]+$/;
+const EVENT_ID_INVALID_CHAR_PATTERN = /[^A-Za-z0-9_]/g;
+
+function sanitizeEventId(value) {
+    return String(value || "").replace(EVENT_ID_INVALID_CHAR_PATTERN, "");
+}
+
+function isValidEventId(value) {
+    const trimmed = String(value || "").trim();
+    if (!trimmed) {
+        return false;
+    }
+    return EVENT_ID_ALLOWED_PATTERN.test(trimmed);
+}
 
 function buildDatePrefix(dateStr) {
     const matched = String(dateStr || "").trim().match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
@@ -41,7 +55,7 @@ function buildDatePrefix(dateStr) {
 
 function buildArticleId(dateStr, eventId) {
     const prefix = buildDatePrefix(dateStr);
-    const safeEventId = String(eventId || "").trim();
+    const safeEventId = sanitizeEventId(String(eventId || "").trim());
     if (!prefix) {
         return safeEventId;
     }
@@ -59,15 +73,15 @@ function extractEventId(articleId, dateStr) {
 
     const prefix = buildDatePrefix(dateStr);
     if (prefix && rawId.startsWith(`${prefix}-`)) {
-        return rawId.slice(prefix.length + 1);
+        return sanitizeEventId(rawId.slice(prefix.length + 1));
     }
 
     const matched = rawId.match(ARTICLE_ID_PATTERN);
     if (matched) {
-        return matched[2];
+        return sanitizeEventId(matched[2]);
     }
 
-    return rawId;
+    return sanitizeEventId(rawId);
 }
 
 function escapeHtml(value) {

--- a/mypage-kamagi/pages/app/blog-maker/modules/validation.js
+++ b/mypage-kamagi/pages/app/blog-maker/modules/validation.js
@@ -87,8 +87,9 @@ function renderValidation() {
 }
 
 function buildExportJson(article, imageMap) {
+    const exportId = buildArticleId(article.date, article.id);
     const payload = {
-        id: article.id.trim(),
+        id: exportId,
         date: article.date.trim(),
         title: article.title.trim(),
         sections: article.sections.map((section, index) => {
@@ -137,14 +138,13 @@ async function onDownloadClick() {
     dom.downloadButton.disabled = true;
 
     try {
-        const randomTag = generateRandomId();
-        const dateStr = state.date.trim();
+        const exportId = buildArticleId(state.date, state.id);
         let imageIndex = 1;
         const imageEntries = [];
         const imageMap = { thumbnail: null, sections: {} };
 
         if (state.thumbnailFile) {
-            const filename = generateImageFilename(dateStr, randomTag, imageIndex);
+            const filename = generateImageFilename(exportId, imageIndex);
             const blob = await convertToWebp(state.thumbnailFile);
             imageEntries.push({ filename, blob });
             imageMap.thumbnail = filename;
@@ -153,7 +153,7 @@ async function onDownloadClick() {
 
         for (let i = 0; i < state.sections.length; i++) {
             if (state.sections[i].imageFile) {
-                const filename = generateImageFilename(dateStr, randomTag, imageIndex);
+                const filename = generateImageFilename(exportId, imageIndex);
                 const blob = await convertToWebp(state.sections[i].imageFile);
                 imageEntries.push({ filename, blob });
                 imageMap.sections[i] = filename;
@@ -194,7 +194,7 @@ function downloadJson(data, fileName) {
 }
 
 function updateDownloadFilename() {
-    const safeId = state.id.trim() || "article";
+    const safeId = buildArticleId(state.date, state.id) || DEFAULT_ARTICLE_BASE_NAME;
     const ext = hasUploadedImages() ? ".zip" : ".json";
     dom.downloadFilename.textContent = `${safeId}${ext}`;
 }

--- a/mypage-kamagi/pages/app/blog-maker/modules/validation.js
+++ b/mypage-kamagi/pages/app/blog-maker/modules/validation.js
@@ -10,6 +10,8 @@ function validateState(article) {
 
     if (!article.id.trim()) {
         errors.push("id未入力です");
+    } else if (!isValidEventId(article.id)) {
+        errors.push("idは半角英数字と_のみ使用できます");
     }
 
     if (!article.date.trim()) {


### PR DESCRIPTION
## 概要（必須）
<!-- なぜこの変更が必要か、何のための変更かを記載してください -->
https://github.com/KAIT-EDTC/EDTCHP/issues/136
タグの追加などはまた別PRで対応する。

## 変更点（必須）
<!--
 追加・修正・削除した内容を簡潔に記載してください
 例: 
 - xx機能の実装(`script/test.js`)
 - ○○デザインの刷新(`aboutedtc.html`)

 特に、デザイン修正時は変更前と変更後のキャプチャをつけてください。
 比較にはMarkdownのテーブルを使うと良いです。

 | 変更前 | 変更後 |
 | - | - |
 | 画像 | 画像 |
-->
- 写真のランダムなスラッグを適当なidに置換するように(`mypage-kamagi/pages/app/blog-maker/modules/image-processor.js`)
- idにイベント名だけを求めるように(`mypage-kamagi/pages/app/blog-maker/modules/utils.js`)
- 変更に伴うバリデーション等

## 再現方法（任意）
<!--
追加機能: 使い方・確認手順
バグ修正: 修正前バグの再現方法と、修正後に解消されたことの確認手順
-->

## 見てほしいこと（必須）
<!--
 レビューで特に確認してほしい観点を記載してください
 例: 
 - [ ] ○○ボタン押下時にxxイベントが発火する
-->
- [x] ブログメーカーにて、インポート/エクスポート時に命名が正しいことを確認
- [x] バリデーションの過不足はないか
- [x] 入力内容とJSONの内容は正しいか

## 懸念点（任意）
<!-- 不安な点、判断に迷っている点、伝えておきたい点、備考などを記載してください -->
idのバリデーションをリアルタイムに行うとUXが悪くなったので、ページ下部の検証結果で警告するようにした。