### PR TITLE
feat: 今日以降のイベントを表示するように

### DIFF
--- a/mypage-kamagi/pages/mypage/auth.js
+++ b/mypage-kamagi/pages/mypage/auth.js
@@ -24,7 +24,8 @@ document.addEventListener('DOMContentLoaded', async () => {
  */
 async function fetchEvents(userId) {
     try {
-        const response = await eventService.getEvents({ userId: userId });
+        const todayStart = getToday();
+        const response = await eventService.getEvents({ userId: userId, startDate: todayStart });
         if (!response.events) return null;
         return response.events;
     } catch (error) {

--- a/mypage-kamagi/pages/mypage/fetch-event.js
+++ b/mypage-kamagi/pages/mypage/fetch-event.js
@@ -96,6 +96,20 @@ function createDescriptionElement(description) {
 }
 
 /**
+ * 今日の日付を「YYYY-MM-DD HH:MM:SS」として取得する。
+ * @returns [string] フォーマットされた今日の日付文字列
+ */
+function getToday() {
+  const today = new Date();
+
+  const year = today.getFullYear();
+  const month = String(today.getMonth() + 1).padStart(2, '0');
+  const day = String(today.getDate()).padStart(2, '0');
+
+  return `${year}-${month}-${day} 00:00:00`;
+}
+
+/**
  * 単日の場合は 「YYYY/MM/DD(曜日): hh:mm 〜 hh:mm」 にフォーマットする。
  * 複数日の場合は 「YYYY/MM/DD 〜 YYYY/MM/DD」 にフォーマットする。(現状は時間表示なし)
  * @param {string} start 日時文字列


### PR DESCRIPTION
## 概要
<!-- [対応したIssueなどのリンク] のバグを修正しました。 -->
過去のイベント表示バグを修正。

## 修正内容
<!--
修正箇所をコードブロックで明記しておくと確認しやすい
- `〇〇.js` における undefined エラーの修正
- APIリクエスト時のパラメータ不足を修正
-->
- マイページトップにて、過去のイベントが表示されてしまう問題を修正

## バグの原因
<!--
なぜバグが発生していたのか、技術的な原因
- `null` が返るケースが考慮されておらず、クラッシュしていた
-->
イベントを取得する際に、取得開始日時を設定していなかった。

## 再現手順(任意)
<!--
再現させるための具体的な手順
画面の遷移など
-->
マイページにて過去のイベントなどを作成して、トップページに表示されていないかを確認する。

## 修正後の動作（確認結果）
<!--
修正が正しく反映されていることを示す証拠
スクリーンショットや動画を添付

修正前と修正後のキャプチャをテーブルにすると比較しやすくて良い
-->
| 過去のイベントと今日以降のイベントを混在させて作成 | 今日以降のイベントのみが表示されている |
| - | - |
|  <img width="650" height="569" alt="image" src="https://github.com/user-attachments/assets/7f5010b4-ae65-4753-8828-4a27534668b6" /> | <img width="1234" height="286" alt="image" src="https://github.com/user-attachments/assets/e8c31f73-36eb-4790-8713-085624a96596" />  |

## 影響範囲・リスク
<!--
この修正によって影響を受ける可能性のある他の機能
認証周りの修正のため、ログイン処理全体に影響がないか確認済み
-->
単一ロジックなので影響なし。

## その他・備考
<!-- レビュアーに伝えておきたいことや、相談事項 -->
