### PR TITLE
ブログを日付順にソートする

### DIFF
--- a/script/blog/blogCardRenderer.js
+++ b/script/blog/blogCardRenderer.js
@@ -13,7 +13,7 @@ export function filterArticles(articles, year, tags) {
             if (!tags.every((tag) => articleTags.includes(tag))) return false;
         }
         return true;
-    });
+    }).sort((a, b) => (b.date ?? "").localeCompare(a.date ?? ""));
 }
 
 export function getAvailableYears(articles) {


### PR DESCRIPTION
## 概要
<!-- [対応したIssueなどのリンク] のバグを修正しました。 -->

## 修正内容
- ブログが追加した順で表示されてしまう

## バグの原因
ソートをしていなかった



## 修正後の動作（確認結果）
|修正前|修正後|
| - | - |
|<img width="1008" height="345" alt="612668812-cf2ce0da-22ef-42b9-ac67-fb9cbe2e6d1a" src="https://github.com/user-attachments/assets/79d19e0d-5b4a-4e77-977d-fd619c0dbaf7" />|<img width="1109" height="483" alt="image" src="https://github.com/user-attachments/assets/24993649-6176-4d02-ba00-99c9880a7cc1" />|


## 影響範囲・リスク

たぶんなし