### PR TITLE
【緊急修正】イベント一覧取得APIの認証エラー

### DIFF
--- a/KAMAGI/api/events.php
+++ b/KAMAGI/api/events.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once __DIR__ . '/../session_start.php';
 require_once __DIR__ . '/../bootstrap.php';
 
 use KAMAGI\Database;

--- a/KAMAGI/api/events.php
+++ b/KAMAGI/api/events.php
@@ -32,22 +32,22 @@ switch ($method) {
         // フィルター無し : 全イベントを取得する(コンボボックス用)
         $eventController->fetchWithFilters();
         break;
-    
+
     case 'POST':
         // イベント作成（参加者情報を含む）
         $eventController->store();
         break;
-    
+
     case 'PUT':
         // イベント更新（参加者情報を含む）
         $eventController->update();
         break;
-    
+
     case 'DELETE':
         // イベント削除
         $eventController->destroy();
         break;
-    
+
     default:
         Response::json(Response::HTTP_METHOD_NOT_ALLOWED, [
             'success' => false,


### PR DESCRIPTION
## 概要
<!-- [対応したIssueなどのリンク] のバグを修正しました。 -->
イベント一覧取得APIの認証エラーを修正した。

## 修正内容
<!--
修正箇所をコードブロックで明記しておくと確認しやすい
- `〇〇.js` における undefined エラーの修正
- APIリクエスト時のパラメータ不足を修正
-->
events.phpに`require_once __DIR__ . '/../session_start.php';`を追加

## バグの原因
<!--
なぜバグが発生していたのか、技術的な原因
- `null` が返るケースが考慮されておらず、クラッシュしていた
-->
events.php(イベントAPI)配下でセッションを共有していないことで認証の`isset($_SESSION['userId'])`などで`undefined`になり弾かれていた。

## 修正後の動作（確認結果）
<!--
修正が正しく反映されていることを示す証拠
スクリーンショットや動画を添付

修正前と修正後のキャプチャをテーブルにすると比較しやすくて良い
-->
|修正前|修正後|
|-|-|
| <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/6a863cc1-0c0b-4d73-8a24-edf58f77f713" /> | <img width="2880" height="1800" alt="image" src="https://github.com/user-attachments/assets/6c731700-7979-4a70-a6c6-e6581ba419a3" /> |

## 影響範囲・リスク
<!--
この修正によって影響を受ける可能性のある他の機能
認証周りの修正のため、ログイン処理全体に影響がないか確認済み
-->
events.phpにセッションファイル読み込みを追加したので、イベントAPI全体で影響がある。
直接的な影響を受けるのは、認証がおかれているイベント一覧取得APIのみ。

## その他・備考
<!-- レビュアーに伝えておきたいことや、相談事項 -->
