### PR TITLE
feat: イベントの参加者の選択を容易にする

### DIFF
--- a/mypage-kamagi/pages/event/event-create.js
+++ b/mypage-kamagi/pages/event/event-create.js
@@ -30,6 +30,7 @@ function setupCreateForm() {
 
             await createEvent(formValues);
             createForm.reset();
+            resetMultiSelect('create');
             await loadEvents();
             
         } catch (error) {
@@ -46,15 +47,13 @@ function setupCreateForm() {
  * @returns {Object} フォームの値
  */
 function getCreateFormValues() {
-    const participantsSelect = document.getElementById('create-participants');
-    
     return {
         title: document.getElementById('create-title').value,
         description: document.getElementById('create-description').value,
         visibility: document.getElementById('create-visibility').value,
         startTime: document.getElementById('create-start-time').value,
         endTime: document.getElementById('create-end-time').value,
-        participantIds: Array.from(participantsSelect.selectedOptions).map(opt => opt.value)
+        participantIds: getMultiSelectValues('create')
     };
 }
 

--- a/mypage-kamagi/pages/event/event-update.js
+++ b/mypage-kamagi/pages/event/event-update.js
@@ -6,15 +6,13 @@
  * 更新フォームをクリア
  */
 function clearUpdateForm() {
-    const updateParticipants = document.getElementById('update-participants');
-    
     document.getElementById('update-event-id').value = '';
     document.getElementById('update-title').value = '';
     document.getElementById('update-description').value = '';
     document.getElementById('update-start-time').value = '';
     document.getElementById('update-end-time').value = '';
     document.getElementById('update-visibility').value = 'public';
-    Array.from(updateParticipants.options).forEach(opt => opt.selected = false);
+    resetMultiSelect('update');
 }
 
 /**
@@ -22,8 +20,6 @@ function clearUpdateForm() {
  * @param {Object} event イベントデータ
  */
 function populateUpdateForm(event) {
-    const updateParticipants = document.getElementById('update-participants');
-    
     document.getElementById('update-event-id').value = event.id;
     document.getElementById('update-title').value = event.title || '';
     document.getElementById('update-description').value = event.description || '';
@@ -33,9 +29,7 @@ function populateUpdateForm(event) {
     
     // 参加者を選択状態にする
     const participantIds = (event.participants || []).map(p => String(p.id));
-    Array.from(updateParticipants.options).forEach(opt => {
-        opt.selected = participantIds.includes(opt.value);
-    });
+    setMultiSelectValues('update', participantIds);
 }
 
 /**
@@ -43,8 +37,6 @@ function populateUpdateForm(event) {
  * @returns {Object} フォームの値
  */
 function getUpdateFormValues() {
-    const updateParticipants = document.getElementById('update-participants');
-    
     return {
         googleEventId: document.getElementById('update-event-id').value,
         title: document.getElementById('update-title').value,
@@ -52,7 +44,7 @@ function getUpdateFormValues() {
         visibility: document.getElementById('update-visibility').value,
         startTime: document.getElementById('update-start-time').value,
         endTime: document.getElementById('update-end-time').value,
-        participantIds: Array.from(updateParticipants.selectedOptions).map(opt => opt.value)
+        participantIds: getMultiSelectValues('update')
     };
 }
 
@@ -103,10 +95,9 @@ function handleUpdateEventSelect() {
  */
 function setupUpdateForm() {
     const updateSelect = document.getElementById('update-event-select');
-    const updateForm = document.getElementById('update-event-form');
-    const updateParticipants = document.getElementById('update-participants');
+    const updateForm   = document.getElementById('update-event-form');
     
-    if (!updateSelect || !updateForm || !updateParticipants) {
+    if (!updateSelect || !updateForm) {
         console.error('event-update: DOM要素が見つかりません。');
         return;
     }

--- a/mypage-kamagi/pages/event/event.js
+++ b/mypage-kamagi/pages/event/event.js
@@ -19,6 +19,10 @@ document.addEventListener('DOMContentLoaded', async () => {
         loadMembers(),
         loadEvents()
     ]);
+
+    // カスタムマルチセレクトの初期化
+    initMultiSelect('create');
+    initMultiSelect('update');
     
     // フォームイベントの設定（各ファイルから読み込まれた関数を呼び出す）
     setupCreateForm();
@@ -73,27 +77,223 @@ async function loadMembers() {
  * 参加者セレクトボックスにメンバー一覧を表示
  */
 function populateMemberSelects() {
-    const createParticipants = document.getElementById('create-participants');
-    const updateParticipants = document.getElementById('update-participants');
-    
+    const createList = document.getElementById('create-participants-list');
+    const updateList = document.getElementById('update-participants-list');
+
     // クリア
-    createParticipants.innerHTML = '';
-    updateParticipants.innerHTML = '';
-    
-    // メンバーをオプションとして追加
+    createList.innerHTML = '';
+    updateList.innerHTML = '';
+
+    if (membersCache.length === 0) {
+        const empty = '<li class="multi-select-empty">メンバーがいません</li>';
+        createList.innerHTML = empty;
+        updateList.innerHTML = empty;
+        return;
+    }
+
     membersCache.forEach(member => {
-        const optionText = `${member.name} (${member.id})`;
-        
-        const createOption = document.createElement('option');
-        createOption.value = member.id;
-        createOption.textContent = optionText;
-        createParticipants.appendChild(createOption);
-        
-        const updateOption = document.createElement('option');
-        updateOption.value = member.id;
-        updateOption.textContent = optionText;
-        updateParticipants.appendChild(updateOption);
+        const label = `${member.name} (${member.id})`;
+        createList.appendChild(buildMultiSelectItem('create', member.id, label));
+        updateList.appendChild(buildMultiSelectItem('update', member.id, label));
     });
+}
+
+/**
+ * チェックボックスリストアイテムの生成
+ * @param {string} prefix  'create' | 'update'
+ * @param {string} value   メンバー ID
+ * @param {string} label   表示テキスト
+ * @returns {HTMLElement}
+ */
+function buildMultiSelectItem(prefix, value, label) {
+    const li = document.createElement('li');
+    li.className = 'multi-select-item';
+    li.dataset.value = value;
+    li.dataset.label = label;
+
+    const cb = document.createElement('input');
+    cb.type = 'checkbox';
+    cb.value = value;
+    cb.id = `${prefix}-member-${value}`;
+
+    const span = document.createElement('span');
+    span.className = 'multi-select-item-label';
+    span.textContent = label;
+
+    li.appendChild(cb);
+    li.appendChild(span);
+
+    // クリックでトグル
+    li.addEventListener('click', (e) => {
+        if (e.target === cb) return; // checkbox直接クリックは自然に処理される
+        cb.checked = !cb.checked;
+        cb.dispatchEvent(new Event('change'));
+    });
+
+    cb.addEventListener('change', () => {
+        li.classList.toggle('checked', cb.checked);
+        multiSelectRefreshTags(prefix);
+    });
+
+    return li;
+}
+
+/**
+ * カスタムマルチセレクトの初期化（開閉、検索、クリア）
+ * @param {string} prefix  'create' | 'update'
+ */
+function initMultiSelect(prefix) {
+    const widget   = document.getElementById(`${prefix}-participants-widget`);
+    const control  = document.getElementById(`${prefix}-participants-control`);
+    const dropdown = document.getElementById(`${prefix}-participants-dropdown`);
+    const search   = document.getElementById(`${prefix}-participants-search`);
+    const clearBtn = document.getElementById(`${prefix}-participants-clear`);
+    const list     = document.getElementById(`${prefix}-participants-list`);
+
+    if (!widget || !control || !dropdown || !search || !clearBtn || !list) return;
+
+    // コントロール全体クリックで開閉トグル
+    control.addEventListener('mousedown', (e) => {
+        // タグのクリアボタンのみ除外（search と widget 内はすべて開く）
+        if (e.target.classList.contains('multi-select-tag-remove') ||
+            e.target === clearBtn) return;
+        // search インプット以外は focus 移動を防ぎドロップダウンを操作
+        if (e.target !== search) e.preventDefault();
+        const isOpen = widget.classList.contains('open');
+        closeAllMultiSelects();
+        if (!isOpen) {
+            widget.classList.add('open');
+            search.focus();
+        }
+    });
+
+    // 検索欄フォーカス時も必ず開く
+    search.addEventListener('focus', () => {
+        widget.classList.add('open');
+    });
+
+    // 検索テキスト入力でフィルタリング
+    search.addEventListener('input', () => {
+        const q = search.value.trim().toLowerCase();
+        let anyVisible = false;
+        list.querySelectorAll('.multi-select-item').forEach(item => {
+            const match = item.dataset.label.toLowerCase().includes(q);
+            item.style.display = match ? '' : 'none';
+            if (match) anyVisible = true;
+        });
+        // 結果なしメッセージ
+        let emptyMsg = list.querySelector('.multi-select-empty');
+        if (!anyVisible) {
+            if (!emptyMsg) {
+                emptyMsg = document.createElement('li');
+                emptyMsg.className = 'multi-select-empty';
+                emptyMsg.textContent = '一致するメンバーがいません';
+                list.appendChild(emptyMsg);
+            }
+        } else if (emptyMsg && emptyMsg.dataset.dynamic) {
+            emptyMsg.remove();
+        }
+        // ドロップダウンを開く
+        widget.classList.add('open');
+    });
+
+    // 検索ボックスでアローキー
+    search.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeAllMultiSelects();
+    });
+
+    // 全クリア
+    clearBtn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        list.querySelectorAll('input[type="checkbox"]:checked').forEach(cb => {
+            cb.checked = false;
+            cb.closest('.multi-select-item').classList.remove('checked');
+        });
+        multiSelectRefreshTags(prefix);
+        search.value = '';
+        list.querySelectorAll('.multi-select-item').forEach(item => item.style.display = '');
+    });
+}
+
+/**
+ * タグ山を再描画
+ * @param {string} prefix
+ */
+function multiSelectRefreshTags(prefix) {
+    const tagsDiv = document.getElementById(`${prefix}-participants-tags`);
+    const search  = document.getElementById(`${prefix}-participants-search`);
+    const widget  = document.getElementById(`${prefix}-participants-widget`);
+    const list    = document.getElementById(`${prefix}-participants-list`);
+
+    // 既存タグを削除
+    tagsDiv.querySelectorAll('.multi-select-tag').forEach(t => t.remove());
+
+    const checked = list.querySelectorAll('input[type="checkbox"]:checked');
+    checked.forEach(cb => {
+        const tag = document.createElement('span');
+        tag.className = 'multi-select-tag';
+        tag.textContent = cb.closest('.multi-select-item').dataset.label;
+
+        const removeBtn = document.createElement('button');
+        removeBtn.type = 'button';
+        removeBtn.className = 'multi-select-tag-remove';
+        removeBtn.textContent = '×';
+        removeBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            cb.checked = false;
+            cb.closest('.multi-select-item').classList.remove('checked');
+            multiSelectRefreshTags(prefix);
+        });
+
+        tag.appendChild(removeBtn);
+        tagsDiv.insertBefore(tag, search);
+    });
+
+    widget.classList.toggle('has-value', checked.length > 0);
+}
+
+/**
+ * すべてのカスタムマルチセレクトを閉じる
+ */
+function closeAllMultiSelects() {
+    document.querySelectorAll('.multi-select.open').forEach(el => el.classList.remove('open'));
+}
+
+// 外側クリックで閉じる
+document.addEventListener('mousedown', (e) => {
+    if (!e.target.closest('.multi-select')) closeAllMultiSelects();
+});
+
+/**
+ * カスタムウィジェットから選択されたID一覧を取得
+ * @param {string} prefix
+ * @returns {string[]}
+ */
+function getMultiSelectValues(prefix) {
+    const list = document.getElementById(`${prefix}-participants-list`);
+    return Array.from(list.querySelectorAll('input[type="checkbox"]:checked')).map(cb => cb.value);
+}
+
+/**
+ * カスタムウィジェットに選択状態を設定
+ * @param {string} prefix
+ * @param {string[]} ids  選択するメンバー ID の配列
+ */
+function setMultiSelectValues(prefix, ids) {
+    const list = document.getElementById(`${prefix}-participants-list`);
+    list.querySelectorAll('input[type="checkbox"]').forEach(cb => {
+        cb.checked = ids.includes(String(cb.value));
+        cb.closest('.multi-select-item').classList.toggle('checked', cb.checked);
+    });
+    multiSelectRefreshTags(prefix);
+}
+
+/**
+ * カスタムウィジェットをリセット
+ * @param {string} prefix
+ */
+function resetMultiSelect(prefix) {
+    setMultiSelectValues(prefix, []);
 }
 
 /**

--- a/mypage-kamagi/pages/event/event.js
+++ b/mypage-kamagi/pages/event/event.js
@@ -190,7 +190,7 @@ function initMultiSelect(prefix) {
                 emptyMsg.textContent = '一致するメンバーがいません';
                 list.appendChild(emptyMsg);
             }
-        } else if (emptyMsg && emptyMsg.dataset.dynamic) {
+        } else if (emptyMsg) {
             emptyMsg.remove();
         }
         // ドロップダウンを開く

--- a/mypage-kamagi/pages/event/index.html
+++ b/mypage-kamagi/pages/event/index.html
@@ -73,11 +73,22 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="create-participants"><i class="fa fa-users"></i> 参加者</label>
-                        <select id="create-participants" name="participant_ids" multiple size="5">
-                            <!-- JSで動的に追加 -->
-                        </select>
-                        <small class="form-hint">Ctrl/Cmdキーで複数選択可。選択するとカレンダーにも表示されます。</small>
+                        <label><i class="fa fa-users"></i> 参加者</label>
+                        <div class="multi-select" id="create-participants-widget">
+                            <div class="multi-select-control" id="create-participants-control">
+                                <div class="multi-select-tags" id="create-participants-tags">
+                                    <input type="text" class="multi-select-search" id="create-participants-search" placeholder="メンバーを検索..." autocomplete="off">
+                                </div>
+                                <button type="button" class="multi-select-clear" id="create-participants-clear" title="すべてクリア">×</button>
+                                <span class="multi-select-arrow">▾</span>
+                            </div>
+                            <div class="multi-select-dropdown" id="create-participants-dropdown">
+                                <ul class="multi-select-list" id="create-participants-list">
+                                    <!-- JSで動的に追加 -->
+                                </ul>
+                            </div>
+                        </div>
+                        <small class="form-hint">選択するとカレンダーにも表示されます。</small>
                     </div>
 
                     <button type="submit" class="btn btn-primary">
@@ -136,11 +147,22 @@
                     </div>
 
                     <div class="form-group">
-                        <label for="update-participants"><i class="fa fa-users"></i> 参加者</label>
-                        <select id="update-participants" name="participant_ids" multiple size="5">
-                            <!-- JSで動的に追加 -->
-                        </select>
-                        <small class="form-hint">Ctrl/Cmdキーで複数選択可。選択するとカレンダーにも表示されます。</small>
+                        <label><i class="fa fa-users"></i> 参加者</label>
+                        <div class="multi-select" id="update-participants-widget">
+                            <div class="multi-select-control" id="update-participants-control">
+                                <div class="multi-select-tags" id="update-participants-tags">
+                                    <input type="text" class="multi-select-search" id="update-participants-search" placeholder="メンバーを検索..." autocomplete="off">
+                                </div>
+                                <button type="button" class="multi-select-clear" id="update-participants-clear" title="すべてクリア">×</button>
+                                <span class="multi-select-arrow">▾</span>
+                            </div>
+                            <div class="multi-select-dropdown" id="update-participants-dropdown">
+                                <ul class="multi-select-list" id="update-participants-list">
+                                    <!-- JSで動的に追加 -->
+                                </ul>
+                            </div>
+                        </div>
+                        <small class="form-hint">選択するとカレンダーにも表示されます。</small>
                     </div>
 
                     <button type="submit" class="btn btn-primary">

--- a/mypage-kamagi/pages/event/style.css
+++ b/mypage-kamagi/pages/event/style.css
@@ -302,22 +302,227 @@ h1 i {
     color: #888;
 }
 
-/* 複数選択 */
-.form-group select[multiple] {
-    height: auto;
-    min-height: 130px;
-    padding: 6px;
+/* カスタムマルチセレクト（チェックボックス付きドロップダウン） */
+.multi-select {
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
 }
 
-.form-group select[multiple] option {
-    padding: 10px 12px;
+.multi-select-control {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 4px;
+    min-height: 48px;
+    padding: 6px 38px 6px 10px;
+    border: 2px solid #e8e8e8;
+    border-radius: 8px;
+    background-color: #fafafa;
+    cursor: text;
+    box-sizing: border-box;
+    transition: border-color 0.2s, background-color 0.2s, box-shadow 0.2s;
+    position: relative;
+}
+
+.multi-select.open .multi-select-control,
+.multi-select-control:focus-within {
+    border-color: var(--main-color);
+    background-color: #fff;
+    box-shadow: 0 0 0 3px rgba(10, 140, 216, 0.1);
+}
+
+.multi-select-tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    flex: 1;
+    align-items: center;
+    min-width: 0;
+}
+
+/* 選択済みタグ */
+.multi-select-tag {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 8px;
+    background-color: var(--main-color);
+    color: #fff;
     border-radius: 4px;
-    margin-bottom: 2px;
+    font-size: 0.82rem;
+    font-weight: 500;
+    white-space: nowrap;
+    animation: tagPop 0.15s ease;
 }
 
-.form-group select[multiple] option:checked {
-    background: linear-gradient(0deg, var(--main-color) 0%, var(--main-color) 100%);
-    color: white;
+@keyframes tagPop {
+    from { transform: scale(0.7); opacity: 0; }
+    to   { transform: scale(1);   opacity: 1; }
+}
+
+.multi-select-tag-remove {
+    background: none;
+    border: none;
+    color: rgba(255,255,255,0.8);
+    cursor: pointer;
+    padding: 0;
+    font-size: 0.9rem;
+    line-height: 1;
+    display: flex;
+    align-items: center;
+}
+
+.multi-select-tag-remove:hover {
+    color: #fff;
+}
+
+/* 検索インプット */
+.multi-select-search {
+    flex: 1;
+    min-width: 80px;
+    border: none !important;
+    background: transparent !important;
+    outline: none !important;
+    box-shadow: none !important;
+    padding: 2px 4px !important;
+    font-size: 0.9rem;
+    color: #333;
+    width: auto !important;
+}
+
+.multi-select-search::placeholder {
+    color: #aaa;
+}
+
+/* クリアボタン */
+.multi-select-clear {
+    position: absolute;
+    right: 28px;
+    top: 50%;
+    transform: translateY(-50%);
+    background: none;
+    border: none;
+    color: #aaa;
+    font-size: 1.1rem;
+    cursor: pointer;
+    padding: 2px 4px;
+    line-height: 1;
+    display: none;
+}
+
+.multi-select-clear:hover {
+    color: #555;
+}
+
+.multi-select.has-value .multi-select-clear {
+    display: block;
+}
+
+/* 矢印 */
+.multi-select-arrow {
+    position: absolute;
+    right: 10px;
+    top: 50%;
+    transform: translateY(-50%);
+    color: #aaa;
+    font-size: 0.9rem;
+    pointer-events: none;
+    transition: transform 0.2s;
+}
+
+.multi-select.open .multi-select-arrow {
+    transform: translateY(-50%) rotate(180deg);
+}
+
+/* ドロップダウン本体 */
+.multi-select-dropdown {
+    display: none;
+    position: absolute;
+    top: calc(100% + 4px);
+    left: 0;
+    right: 0;
+    background: #fff;
+    border: 2px solid #e8e8e8;
+    border-radius: 8px;
+    box-shadow: 0 8px 24px rgba(0,0,0,0.12);
+    z-index: 999;
+    max-height: 220px;
+    overflow-y: auto;
+    animation: dropdownOpen 0.15s ease;
+}
+
+.multi-select.open .multi-select-dropdown {
+    display: block;
+}
+
+@keyframes dropdownOpen {
+    from { opacity: 0; transform: translateY(-6px); }
+    to   { opacity: 1; transform: translateY(0); }
+}
+
+/* スクロールバー */
+.multi-select-dropdown::-webkit-scrollbar {
+    width: 6px;
+}
+.multi-select-dropdown::-webkit-scrollbar-thumb {
+    background: #ddd;
+    border-radius: 3px;
+}
+
+/* リストアイテム */
+.multi-select-list {
+    list-style: none;
+    margin: 0;
+    padding: 4px;
+}
+
+.multi-select-item {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-radius: 6px;
+    cursor: pointer;
+    font-size: 0.92rem;
+    color: #333;
+    transition: background-color 0.12s;
+    user-select: none;
+}
+
+.multi-select-item:hover {
+    background-color: #f0f7ff;
+}
+
+.multi-select-item.checked {
+    background-color: #edf4ff;
+}
+
+.multi-select-item input[type="checkbox"] {
+    width: 16px;
+    height: 16px;
+    min-width: 16px;
+    accent-color: var(--main-color);
+    cursor: pointer;
+    border: none;
+    padding: 0;
+    margin: 0;
+    background: transparent;
+    box-shadow: none;
+}
+
+.multi-select-item-label {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.multi-select-empty {
+    padding: 12px;
+    text-align: center;
+    color: #aaa;
+    font-size: 0.88rem;
 }
 
 /* 削除プレビュー */


### PR DESCRIPTION
## 概要（必須）

イベント管理ページ（マイページ）において、参加者の複数選択UIを改善しました。
従来は `<select multiple>` を使用しており Ctrl/Cmd キーを押しながら選択する必要があり直感的ではありませんでした。
これをチェックボックス付きドロップダウン＋検索フィールドを備えたカスタムUIに置き換え、操作性を大幅に向上させました。

---

## 変更点（必須）

### フロントエンド

- **参加者選択UIをカスタムマルチセレクトに変更** (`mypage-kamagi/pages/event/event.js`, `index.html`, `style.css`)
  - `<select multiple>` を廃止し、チェックボックスリスト＋インライン検索フィールドを持つドロップダウンウィジェットに置き換え
  - 選択済みメンバーはタグとして入力欄に表示され、タグの `×` ボタンで個別削除可能
  - 全クリアボタン（`×`）を追加
  - メンバー名で絞り込み検索が可能
  - ウィジェット外クリックで自動的に閉じる
  - 新規作成フォーム・更新フォームの両方に対応

| 変更前 | 変更後 |
| - | - |
| <img width="673" height="285" alt="image" src="https://github.com/user-attachments/assets/97f98223-8736-42c2-90fb-37ab486c862d" /> |<img width="666" height="209" alt="image" src="https://github.com/user-attachments/assets/57ea4076-0f16-4a2f-b004-75541a7cf611" /> |

動作動画↓
<img width="800" height="432" alt="ezgif-83f332990061bcae" src="https://github.com/user-attachments/assets/0c893a6e-d9ac-4a14-b4c1-69dc7020d49d" />

---

## 見てほしいこと（必須）

- [x] 参加者ドロップダウンが正常に開閉されるか（新規作成・更新フォーム両方）
- [x] チェックボックスを選択するとタグが表示され、タグ `×` で個別解除できるか
- [x] 検索フィールドでメンバー名を入力すると絞り込まれるか
- [x] フォーム送信時に選択した参加者 ID が正しく送信されるか（`getMultiSelectValues()` の動作）
- [x] 更新フォームを開いたとき、既存の参加者が選択済み状態で復元されるか（`setMultiSelectValues()` の動作）

---

## 確認方法（任意）

1. `docker compose up` でローカル環境を起動
2. マイページにログインし、イベント管理ページを開く
3. 「イベントを追加」フォームの参加者欄をクリック → ドロップダウンが開くことを確認
4. 複数メンバーを選択し、タグが表示されることを確認
5. 検索欄に名前を入力して絞り込みが動作することを確認
6. 既存イベントの編集フォームを開き、参加者が復元されることを確認

---

## 懸念点（任意）

- `getToday()` はブラウザのローカル時刻を使用するため、タイムゾーンが異なる環境では意図しない日付になる可能性があります。
- カスタムウィジェットはキーボード操作（矢印キーでの項目移動）に未対応です（アクセシビリティ対応は今後の課題）。
